### PR TITLE
Refactor: Add error handling to coffee actions

### DIFF
--- a/src/actions/coffees.ts
+++ b/src/actions/coffees.ts
@@ -14,14 +14,19 @@ export const addCoffee = async (formData: FormData) => {
   const coffees = parseInt(formData.get("coffees") as string);
   const email = formData.get("email") as string;
   const payload: TablesUpdate<"users"> = { id, coffees: coffees + 1 };
-  await supabase.from(TABLE_NAME).upsert(payload);
-  posthog.capture({
-    distinctId: email,
-    event: "coffee_added",
-    properties: { coffees: coffees + 1 },
-  });
+  try {
+    await supabase.from(TABLE_NAME).upsert(payload);
+    posthog.capture({
+      distinctId: email,
+      event: "coffee_added",
+      properties: { coffees: coffees + 1 },
+    });
 
-  revalidatePath("/admin");
+    revalidatePath("/admin");
+  } catch (error) {
+    console.error("Error adding coffee:", error);
+    return { error: "Failed to add coffee." };
+  }
 };
 
 export const resetCoffee = async (FormData: FormData) => {
@@ -29,15 +34,25 @@ export const resetCoffee = async (FormData: FormData) => {
 
   const id = FormData.get("id") as string;
   const payload: TablesUpdate<"users"> = { id, coffees: 0 };
-  await supabase.from(TABLE_NAME).upsert(payload);
-  revalidatePath("/admin");
+  try {
+    await supabase.from(TABLE_NAME).upsert(payload);
+    revalidatePath("/admin");
+  } catch (error) {
+    console.error("Error resetting coffee:", error);
+    return { error: "Failed to reset coffee." };
+  }
 };
 
 export const deleteCoffee = async (FormData: FormData) => {
   const supabase = await createClient();
 
   const id = FormData.get("id") as string;
-  await supabase.from(TABLE_NAME).delete().eq("id", id);
-  revalidatePath("/admin");
-  redirect("/admin");
+  try {
+    await supabase.from(TABLE_NAME).delete().eq("id", id);
+    revalidatePath("/admin");
+    redirect("/admin");
+  } catch (error) {
+    console.error("Error deleting coffee:", error);
+    return { error: "Failed to delete coffee." };
+  }
 };


### PR DESCRIPTION
This commit introduces error handling to the Supabase queries in `src/actions/coffees.ts`.

- Supabase calls in `addCoffee`, `resetCoffee`, and `deleteCoffee` are now wrapped in try/catch blocks.
- Errors are logged to the console using `console.error`.
- Functions now return an object `{ error: 'message' }` if a Supabase operation fails.
- `revalidatePath` and `redirect` are only called on successful operations.

These changes make the coffee management actions more robust by ensuring that errors are caught and can be handled gracefully by the application.